### PR TITLE
feat: 회원가입 페이지 기능 구현 (#7)

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -62,7 +62,18 @@ type CommonResponse<T = undefined> = {
 
 type NicknameCheckResponse = CommonResponse<{ isExist: boolean }>;
 type EmailVerificationRequest = { email: string };
-type EmailVerificationConfirmRequest = { email: string; code: string };
+type EmailVerificationConfirmRequest = {
+  email: string;
+  emailVerificationCode: string;
+};
+
+type SignupRequest = {
+  email: string;
+  nickname: string;
+  password: string;
+  phoneNumber: string;
+};
+type SignupResponse = CommonResponse<{ userId: number }>;
 
 export const AuthApi = {
   login: (payload: LoginRequest) =>
@@ -86,4 +97,6 @@ export const AuthApi = {
       "/api/auth/email-verification/confirm",
       payload,
     ),
+  signup: (payload: SignupRequest) =>
+    apiClient.post<SignupResponse>("/api/auth/signup", payload),
 };


### PR DESCRIPTION
## 🚨 관련 이슈
Closes #7

[//]: # "작성하실 때는 '#이슈 번호'를 남겨주시면 자동으로 링크가 생성됩니다."

## ✨ 변경사항

[//]: # "어떤 변경사항이 있었나요? 체크해주세요 !"

- [ ] 🐞 BugFix Something isn't working
- [ ] 💻 CrossBrowsing Browser compatibility
- [ ] 🌏 Deploy Deploy
- [ ] 🎨 Design Markup & styling
- [ ] 📃 Docs Documentation writing and editing (README.md, etc.)
- [x] ✨ Feature Feature
- [ ] 🔨 Refactor Code refactoring
- [ ] ⚙️ Setting Development environment setup
- [ ] ✅ Test Test related (storybook, jest, etc.)

## ✏️ 작업 내용

[//]: # "작업 내용을 작성해주세요. 스크린샷을 첨부해주셔도 좋습니다."

회원가입 페이지 기능 구현을 완료했습니다.
사용자가 닉네임 입력부터 이메일 인증, 비밀번호 설정까지 단계적으로 회원가입을 진행할 수 있도록 구현했습니다.
입력값 검증 및 인증 로직을 포함하여, 각 항목이 유효할 때만 회원가입 버튼이 활성화되도록 처리했습니다.

## 😅 미완성 작업

- N/A

## 📢 논의 사항 및 참고 사항

[//]: # "리뷰어가 알면 좋은 내용을 작성해주세요."

- **비밀번호 및 닉네임 형식**  
  - 현재 별도의 형식(규칙)이 지정되어 있지 않아,  
    허용 범위(예: 최소/최대 길이, 특수문자 포함 여부 등)를 정해야 할 필요가 있습니다.  

- **이메일 인증 로직 개선**  
  - 현재는 이미 존재하는 이메일의 경우,  
    인증번호를 입력해도 회원가입이 진행되지 않도록만 처리되어 있습니다.  
  - 개선 방안으로, **“이메일 인증 버튼을 클릭했을 때”**  
    이미 존재하는 이메일이면 인증 메일이 발송되지 않고  
    **“이미 존재하는 이메일입니다.”** 라는 안내 문구를 표시하도록 수정이 필요합니다.  
